### PR TITLE
MachO: Include other zerofill section types

### DIFF
--- a/elfesteem/macho/loaders.py
+++ b/elfesteem/macho/loaders.py
@@ -573,7 +573,7 @@ class segment_command(LoadCommand):
         from elfesteem.macho.sections import Section, Reloc, SymbolStubList, SymbolPtrList
         self.sect = []
         for sh in self.sh:
-            if sh.type == S_ZEROFILL:
+            if sh.type == S_ZEROFILL or sh.type == S_THREAD_LOCAL_ZEROFILL or sh.type == S_GB_ZEROFILL:
                 sh.sect = Section(parent=sh, content=data_empty)
             elif sh.type == S_SYMBOL_STUBS:
                 sh.sect = SymbolStubList(parent=sh, content=raw, start=sh.offset)


### PR DESCRIPTION
There are two other zerofill section types. These should be considered when parsing sections.