### PR TITLE
exmaples: support Python 3+ in otool example

### DIFF
--- a/examples/otool.py
+++ b/examples/otool.py
@@ -342,7 +342,7 @@ if __name__ == '__main__':
         try:
             e = macho_init.MACHO(raw,
                 parseSymbols = False)
-        except ValueError, err:
+        except ValueError as err:
             print("%s:" %file)
             print("    %s" % err)
             continue


### PR DESCRIPTION
This retains support for at least Python 2.6 while supporting Python 3.