### PR TITLE
ELF Resize and other miscellaneous improvements

### DIFF
--- a/tests/test_elf_manipulation.py
+++ b/tests/test_elf_manipulation.py
@@ -161,7 +161,7 @@ def test_ELF_small64(assertion):
               'Packing after reading elf64_small.out')
     # Packed file is identical :-)
     d = e.sh.readelf_display().encode('latin1')
-    assertion('6d4aa86afdbf612430cb699987bc22b9',
+    assertion('c497dd6a4e9aa54fb5f65ee3b8f9de3e',
               hashlib.md5(d).hexdigest(),
               'Display Section Headers (readelf, 64bit)')
     d = e.getsectionbyname('.symtab').readelf_display().encode('latin1')
@@ -234,7 +234,11 @@ def test_ELF_offset_to_sections(assertion):
     data = StrPatchwork(ELF().pack())
     data[88+20] = struct.pack("<I", 0x1000)
     ELF(data)
-    assertion([('error', ('Offset to end of section %d after end of file', 0), {})],
+    assertion([('error', ('Offset to end of section %d after end of file', 0), {}),
+                    ("error", ('Section offset overlap for ' + \
+                            "[                00000000 001000 00000000 0] " + \
+                            '[.text           00000034 000000 00000000 6]',), {})
+                ],
               log_history,
               'Section offset+size too far away (logs)')
     log_history = []


### PR DESCRIPTION
I have used this library as a base for elf manipulation in a static patcher and made various improvements and tweaks. The main thing is the reimplementation of section resize that considers the current layout.
I'll be honest I haven't done that much testing and I'm sure some cases that have not been tested, but I have many checks in place to make sure that the library will crash instead of producing an invalid binary.

The other changes I've made include:
* some docs with typing
* added GNU Symbol Version support
* debug loggers for some functions
* prevent an infinite loop in virt.__init__
* check for section overlap in ELF.check_coherency
* wide output for readelf_display (it's 2024, we have enough screen real estate)

I've made all the required changes for python2.7 and 2.3, [BUT PLEASE STOP SUPPORTING IT.](https://www.python.org/doc/sunset-python-2/).
Python3 was released in 2008, py2 was meant to be deprecated in 2015, then extended to 2020.
It's 2024, It's been deprecated for 4 years after.
Don't enable people who use it, and if you are using it please migrate to py3. 